### PR TITLE
Fix markdown parsing

### DIFF
--- a/.github/workflows/check_links.py
+++ b/.github/workflows/check_links.py
@@ -123,6 +123,10 @@ def check_link(link):
     elif "#" in link and \
         code[1] is not None \
         and 'href=\"' + link[link.find("#"):] + '\"' not in \
+        code[1] \
+        and 'name=\"' + link[link.find("#")+1:] + '\"' not in \
+        code[1] \
+        and 'name=\"user-content-' + link[link.find("#") + 1:] + '\"' not in \
         code[1]:
         if ignore:
             print(


### PR DESCRIPTION
This fixes the links still not properly parsing on this repositories markdown, checks for a prepended `user-content-` tag as well